### PR TITLE
Bump sorcery version and add compatibility for sorcery 0.13.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    sorcery-jwt (0.1.6)
+    sorcery-jwt (0.1.7)
       jwt (~> 1.0)
-      sorcery (~> 0.12.0)
+      sorcery (~> 0.13.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    bcrypt (3.1.12)
+    bcrypt (3.1.13)
     coderay (1.1.2)
     diff-lcs (1.3)
     faraday (0.15.4)
@@ -17,7 +17,7 @@ GEM
     method_source (0.8.2)
     multi_json (1.13.1)
     multi_xml (0.6.0)
-    multipart-post (2.0.0)
+    multipart-post (2.1.1)
     oauth (0.5.4)
     oauth2 (1.4.1)
       faraday (>= 0.8, < 0.16.0)
@@ -29,7 +29,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rack (2.0.6)
+    rack (2.0.7)
     rake (10.5.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -45,7 +45,7 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
     slop (3.6.0)
-    sorcery (0.12.0)
+    sorcery (0.13.0)
       bcrypt (~> 3.1)
       oauth (~> 0.4, >= 0.4.4)
       oauth2 (~> 1.0, >= 0.8.0)

--- a/lib/sorcery/jwt/version.rb
+++ b/lib/sorcery/jwt/version.rb
@@ -1,5 +1,5 @@
 module Sorcery
   module Jwt
-    VERSION = "0.1.6".freeze
+    VERSION = "0.1.7".freeze
   end
 end

--- a/sorcery-jwt.gemspec
+++ b/sorcery-jwt.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
 
   spec.add_runtime_dependency "jwt", "~> 1.0"
-  spec.add_runtime_dependency "sorcery", "~> 0.12.0"
+  spec.add_runtime_dependency "sorcery", "~> 0.13.0"
 end

--- a/spec/sorcery/jwt_spec.rb
+++ b/spec/sorcery/jwt_spec.rb
@@ -2,8 +2,4 @@ RSpec.describe Sorcery::Jwt do
   it "has a version number" do
     expect(Sorcery::Jwt::VERSION).not_to be nil
   end
-
-  it "does something useful" do
-    expect(false).to eq(true)
-  end
 end


### PR DESCRIPTION
Sorcery updated to version 0.13.0, so this PR allows compatibility with the new version. I also deleted an erroneous test