### PR TITLE
Update requirements for sorcery

### DIFF
--- a/sorcery-jwt.gemspec
+++ b/sorcery-jwt.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
 
   spec.add_runtime_dependency "jwt", ">= 1.0", "< 3.0"
-  spec.add_runtime_dependency "sorcery", ">= 0.13", "< 0.16"
+  spec.add_runtime_dependency "sorcery", ">= 0.13", "< 0.17"
 end


### PR DESCRIPTION
Because it is not possible to use the latest version of Sorcery.
(The latest version of sorcery is 0.16.x.)